### PR TITLE
Change column-major camera matrices to row-major.

### DIFF
--- a/src/cam_info_reader.cpp
+++ b/src/cam_info_reader.cpp
@@ -35,12 +35,12 @@ bool CamInfoReader::loadCamParams() {
 
   cam_info_.K[0] = intrinsics_in[0];
   cam_info_.K[1] = 0.0;
-  cam_info_.K[2] = 0.0;
+  cam_info_.K[2] = intrinsics_in[2];
   cam_info_.K[3] = 0.0;
   cam_info_.K[4] = intrinsics_in[1];
-  cam_info_.K[5] = 0.0;
-  cam_info_.K[6] = intrinsics_in[2];
-  cam_info_.K[7] = intrinsics_in[3];
+  cam_info_.K[5] = intrinsics_in[3];
+  cam_info_.K[6] = 0.0;
+  cam_info_.K[7] = 0.0;
   cam_info_.K[8] = 1.0;
 
   std::vector<double> resolution_in;
@@ -85,14 +85,14 @@ bool CamInfoReader::loadCamParams() {
   cam_info_.P[0] = cam_info_.K[0];
   cam_info_.P[1] = cam_info_.K[1];
   cam_info_.P[2] = cam_info_.K[2];
-  cam_info_.P[3] = cam_info_.K[3];
-  cam_info_.P[4] = cam_info_.K[4];
-  cam_info_.P[5] = cam_info_.K[5];
-  cam_info_.P[6] = cam_info_.K[6];
-  cam_info_.P[7] = cam_info_.K[7];
-  cam_info_.P[8] = cam_info_.K[8];
-  cam_info_.P[9] = 0.0;
-  cam_info_.P[10] = 0.0;
+  cam_info_.P[3] = 0.0;
+  cam_info_.P[4] = cam_info_.K[3];
+  cam_info_.P[5] = cam_info_.K[4];
+  cam_info_.P[6] = cam_info_.K[5];
+  cam_info_.P[7] = 0.0;
+  cam_info_.P[8] = cam_info_.K[6];
+  cam_info_.P[9] = cam_info_.K[7];
+  cam_info_.P[10] = cam_info_.K[8];
   cam_info_.P[11] = 0.0;
 
   return true;

--- a/src/image_undistort.cpp
+++ b/src/image_undistort.cpp
@@ -34,10 +34,9 @@ void ImageUndistort::newFrameCallback(
 
 void ImageUndistort::camInfoCallback(
     const sensor_msgs::CameraInfoConstPtr& camera_msg) {
-  Eigen::Matrix3d K;
-  for (size_t i = 0; i < camera_msg->K.size(); ++i) {
-    K(i) = camera_msg->K[i];
-  }
+  Eigen::Matrix3d K =
+      Eigen::Map<const Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>(
+          camera_msg->K.elems);
 
   const cv::Size resolution(camera_msg->width, camera_msg->height);
 


### PR DESCRIPTION
The ROS sensor_msgs/CameraInfo specifies the camera matrices K and P to be row-major. The pull request addresses the switch from the current column-major implementation (as used by Eigen) to row-major.