### PR TITLE
Add stripping the leading slash from camera topic names as a param

### DIFF
--- a/include/image_undistort/image_undistort.h
+++ b/include/image_undistort/image_undistort.h
@@ -37,6 +37,9 @@ constexpr bool kDefaultProcessImage = true;
 constexpr bool kDefaultUndistortImage = true;
 // downsamples output rate if <= 1, every frame is processed.
 constexpr int kDefaultProcessEveryNthFrame = 1;
+// whether to strip the leading slash from the ros camera topic name for
+// input images, which makes the name resolution relative rather than absolute
+constexpr bool kDefaultRelativeCameraTopic = false;
 
 class ImageUndistort {
  public:

--- a/src/image_undistort.cpp
+++ b/src/image_undistort.cpp
@@ -284,5 +284,13 @@ bool ImageUndistort::loadCameraParameters(
     }
   }
 
+  // Strip leading slash from rostopic name if the param is set.
+  bool relative_camera_topic = false;
+  private_nh_.param("relative_camera_topic", relative_camera_topic,
+                    relative_camera_topic);
+  if (relative_camera_topic && image_topic->front() == '/') {
+    image_topic->erase(0, 1);
+  }
+
   return true;
 }

--- a/src/image_undistort.cpp
+++ b/src/image_undistort.cpp
@@ -285,7 +285,7 @@ bool ImageUndistort::loadCameraParameters(
   }
 
   // Strip leading slash from rostopic name if the param is set.
-  bool relative_camera_topic = false;
+  bool relative_camera_topic = kDefaultRelativeCameraTopic;
   private_nh_.param("relative_camera_topic", relative_camera_topic,
                     relative_camera_topic);
   if (relative_camera_topic && image_topic->front() == '/') {


### PR DESCRIPTION
set `relative_camera_topic` to true to activate converting `/cam0/image_raw` to `cam0/image_raw`. This is to support names like `/elster/cam0/image_raw`.