### PR TITLE
Added some parameter checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ A simple node for undistorting images. Handles both plumb bob (aka radial-tangen
 * **scale** Only used if **output_camera_info_source** is set to "auto_generated". The output focal length will be multiplied by this value. This has the effect of resizing the image by this scale factor. (default: 1.0).
 * **publish_tf** True to publish the tf between the input and output image. If the undistortion involves changes to the rotation matrix the frame that the image is in will change. This tf gives that change. (default: true)
 * **output_frame** The name of the frame of the output images. (default: "output_camera")
+* **rename_input_frame** If the input frame should be renamed in the published topics and tf tree. (default: false)
+* **input_frame** Only used if **rename_input_frame** is true. The name of the frame of the input images. (default: "input_camera")
 * **rename_radtan_plumb_bob** If true the radial-tangential distortion model will be called "plumb_bob" in the output camera_info, this is needed by some ros image processing nodes. If false it will be called "radtan". (default: false).
 
 ##Input/Output Topics
@@ -85,6 +87,9 @@ A node that takes in the images and properties of two cameras and outputs rectif
 * **scale** The output focal length will be multiplied by this value. This has the effect of resizing the image by this scale factor. (default: 1.0).
 * **publish_tf** True to publish the tf between the left input and output image. If the undistortion involves changes to the rotation matrix the frame that the image is in will change. This tf gives that change. (default: true)
 * **output_frame** The name of the frame of the output images. (default: "left_camera_rect")
+* **rename_input_frame** If the input frame should be renamed in the published topics and tf tree. (default: false)
+* **left_input_frame** Only used if **rename_input_frame** is true. The name of the frame of the left input images. (default: "left_camera")
+* **right_input_frame** Only used if **rename_input_frame** is true. The name of the frame of the right input images. (default: "right_camera")
 **rename_radtan_plumb_bob** If true the radial-tangential distortion model will be called "plumb_bob" in the output camera_info, this is needed by some ros image processing nodes. If false it will be called "radtan". (default: false).
 
 ##Input/Output Topics
@@ -115,6 +120,9 @@ A node for producing dense stereo images. Internally this node simply combines 3
 * **scale** The output focal length will be multiplied by this value. This has the effect of resizing the image by this scale factor. (default: 1.0).
 * **publish_tf** True to publish the tf between the left input and output image. If the undistortion involves changes to the transformation matrix the frame that the image is in will change, this occurs during most image rectifications. This tf gives that change. (default: true)
 * **output_frame** The name of the frame of the output images. (default: "left_camera_rect")
+* **rename_input_frame** If the input frame should be renamed in the published topics and tf tree. (default: false)
+* **left_input_frame** Only used if **rename_input_frame** is true. The name of the frame of the left input images. (default: "left_camera")
+* **right_input_frame** Only used if **rename_input_frame** is true. The name of the frame of the right input images. (default: "right_camera")
 **rename_radtan_plumb_bob** If true the radial-tangential distortion model will be called "plumb_bob" in the output camera_info, this is needed by some ros image processing nodes. If false it will be called "radtan". (default: false).
 
 ###Note:

--- a/include/image_undistort/image_undistort.h
+++ b/include/image_undistort/image_undistort.h
@@ -61,6 +61,10 @@ constexpr double kDefaultScale = 1.0;
 constexpr bool kDefaultPublishTF = true;
 // name of output image frame
 const std::string kDefaultOutputFrame = "output_camera";
+// rename input frames
+constexpr bool kDefaultRenameInputFrame = false;
+// new name of input frame (only used if rename_input_frame = true)
+const std::string kDefaultInputFrame = "input_camera";
 // if radtan distortion should be called radtan (ASL standard) or plumb_bob (ros
 // standard)
 constexpr bool kDefaultRenameRadtanPlumbBob = false;
@@ -127,6 +131,8 @@ class ImageUndistort {
   double scale_;
   bool publish_tf_;
   std::string output_frame_;
+  bool rename_input_frame_;
+  std::string input_frame_;
   bool rename_radtan_plumb_bob_;
 
   int frame_counter_;

--- a/include/image_undistort/stereo_undistort.h
+++ b/include/image_undistort/stereo_undistort.h
@@ -45,6 +45,12 @@ constexpr double kDefaultScale = 1.0;
 constexpr bool kDefaultPublishTF = true;
 // name of output image frame
 const std::string kDefaultOutputFrame = "left_camera_rect";
+// rename input frames
+constexpr bool kDefaultRenameInputFrame = false;
+// new name of left input frame
+const std::string kDefaultLeftInputFrame = "left_camera";
+// new name of right input frame
+const std::string kDefaultRightInputFrame = "right_camera";
 // if radtan distortion should be called radtan (ASL standard) or plumb_bob (ros
 // standard)
 constexpr bool kDefaultRenameRadtanPlumbBob = false;
@@ -125,6 +131,9 @@ class StereoUndistort {
   std::string output_image_type_;
   bool publish_tf_;
   std::string output_frame_;
+  bool rename_input_frame_;
+  std::string left_input_frame_;
+  std::string right_input_frame_;
   bool rename_radtan_plumb_bob_;
   int frame_counter_;
 };

--- a/include/image_undistort/undistorter.h
+++ b/include/image_undistort/undistorter.h
@@ -36,13 +36,8 @@ class Undistorter {
  private:
   const CameraParametersPair used_camera_parameters_pair_;
 
-#if (defined(CV_VERSION_EPOCH) && CV_VERSION_EPOCH == 2)
   cv::Mat map_x_;
   cv::Mat map_y_;
-#else
-  cv::UMat map_x_;
-  cv::UMat map_y_;
-#endif
 
   double empty_pixels_;
 };

--- a/launch/undistort_basic.launch
+++ b/launch/undistort_basic.launch
@@ -1,10 +1,10 @@
 <launch>
 
-<arg name="mav_name" default="euroc6" />
+<arg name="mav_name" default="elster" />
 <arg name="namespace" default="$(arg mav_name)" />
 <arg name="input_camera_name" default="cam0" />
 <arg name="scale" default="1.0" />
-<arg name="calib_path" default="/home/z/datasets/tangobird/camchain-tango.yaml"/>
+<arg name="calib_path" default="$(find mav_startup)/parameters/mavs/elster/camchain_p23037.yaml"/>
 
 <group ns="$(arg namespace)">
 
@@ -13,7 +13,7 @@
     <param name="input_camera_info_from_ros_params" value = "true"/>    
     <param name="scale" value="$(arg scale)"/>
     <rosparam file="$(arg calib_path)"/>
-    <remap from="input/image" to="ros_vio_publisher/fisheye_left"/>
+    <remap from="input/image" to="$(arg input_camera_name)/image_raw"/>
   </node>
 </group>
 

--- a/launch/undistort_basic.launch
+++ b/launch/undistort_basic.launch
@@ -1,10 +1,10 @@
 <launch>
 
-<arg name="mav_name" default="elster" />
+<arg name="mav_name" default="euroc6" />
 <arg name="namespace" default="$(arg mav_name)" />
 <arg name="input_camera_name" default="cam0" />
 <arg name="scale" default="1.0" />
-<arg name="calib_path" default="$(find mav_startup)/parameters/mavs/elster/camchain_p23037.yaml"/>
+<arg name="calib_path" default="/home/z/datasets/tangobird/camchain-tango.yaml"/>
 
 <group ns="$(arg namespace)">
 
@@ -13,7 +13,7 @@
     <param name="input_camera_info_from_ros_params" value = "true"/>    
     <param name="scale" value="$(arg scale)"/>
     <rosparam file="$(arg calib_path)"/>
-    <remap from="input/image" to="$(arg input_camera_name)/image_raw"/>
+    <remap from="input/image" to="ros_vio_publisher/fisheye_left"/>
   </node>
 </group>
 

--- a/src/dense_stereo_node.cpp
+++ b/src/dense_stereo_node.cpp
@@ -29,12 +29,11 @@ int main(int argc, char** argv) {
   XmlRpc::XmlRpcValue disparity_params;
   ros::param::get(disparity_name, disparity_params);
   if(!disparity_params.hasMember("approximate_sync")){
-    disparity_params["approximate_sync"] = true;
+    ros::param::set(disparity_name + "/approximate_sync", true);
   }
   if(!disparity_params.hasMember("queue_size")){
-    disparity_params["queue_size"] = queue_size;
+    ros::param::set(disparity_name + "/queue_size", queue_size);
   }
-  ros::param::set(disparity_name, disparity_params);
 
   nodelet::M_string disparity_remap;
   disparity_remap["left/image_rect"] = ros::names::resolve("rect/left/image");
@@ -54,12 +53,11 @@ int main(int argc, char** argv) {
 
   ros::param::get(pointcloud_name, pointcloud_params);
   if(!pointcloud_params.hasMember("approximate_sync")){
-    pointcloud_params["approximate_sync"] = true;
+    ros::param::set(pointcloud_name + "/approximate_sync", true);
   }
   if(!pointcloud_params.hasMember("queue_size")){
-    pointcloud_params["queue_size"] = queue_size;
+    ros::param::set(pointcloud_name + "/queue_size", queue_size);
   }
-  ros::param::set(pointcloud_name, pointcloud_params);
 
   nodelet::M_string pointcloud_remap;
   pointcloud_remap["left/camera_info"] =

--- a/src/image_undistort.cpp
+++ b/src/image_undistort.cpp
@@ -84,10 +84,18 @@ ImageUndistort::ImageUndistort(const ros::NodeHandle& nh,
 
   nh_private_.param("publish_tf", publish_tf_, kDefaultPublishTF);
   nh_private_.param("output_frame", output_frame_, kDefaultOutputFrame);
+  if (output_frame_ == "") {
+    ROS_ERROR("Output frame cannot be blank, setting to default");
+    output_frame_ = kDefaultOutputFrame;
+  }
 
   nh_private_.param("rename_input_frame", rename_input_frame_,
                     kDefaultRenameInputFrame);
   nh_private_.param("input_frame", input_frame_, kDefaultInputFrame);
+  if (input_frame_ == "") {
+    ROS_ERROR("Input frame cannot be blank, setting to default");
+    input_frame_ = kDefaultInputFrame;
+  }
 
   // setup subscribers
   std::string input_camera_namespace;

--- a/src/image_undistort.cpp
+++ b/src/image_undistort.cpp
@@ -84,7 +84,7 @@ ImageUndistort::ImageUndistort(const ros::NodeHandle& nh,
 
   nh_private_.param("publish_tf", publish_tf_, kDefaultPublishTF);
   nh_private_.param("output_frame", output_frame_, kDefaultOutputFrame);
-  if (output_frame_ == "") {
+  if (output_frame_.empty()) {
     ROS_ERROR("Output frame cannot be blank, setting to default");
     output_frame_ = kDefaultOutputFrame;
   }
@@ -92,7 +92,7 @@ ImageUndistort::ImageUndistort(const ros::NodeHandle& nh,
   nh_private_.param("rename_input_frame", rename_input_frame_,
                     kDefaultRenameInputFrame);
   nh_private_.param("input_frame", input_frame_, kDefaultInputFrame);
-  if (input_frame_ == "") {
+  if (input_frame_.empty()) {
     ROS_ERROR("Input frame cannot be blank, setting to default");
     input_frame_ = kDefaultInputFrame;
   }
@@ -234,7 +234,7 @@ void ImageUndistort::imageCallback(
     if (rename_input_frame_) {
       frame = input_frame_;
     }
-    if (frame == "") {
+    if (frame.empty()) {
       ROS_ERROR_ONCE("Image frame name is blank, cannot construct tf");
     } else {
       br_.sendTransform(tf::StampedTransform(tf::Transform(R_ros, p_ros),

--- a/src/stereo_undistort.cpp
+++ b/src/stereo_undistort.cpp
@@ -64,13 +64,25 @@ StereoUndistort::StereoUndistort(const ros::NodeHandle& nh,
 
   nh_private_.param("publish_tf", publish_tf_, kDefaultPublishTF);
   nh_private_.param("output_frame", output_frame_, kDefaultOutputFrame);
+  if (output_frame_ == "") {
+    ROS_ERROR("Output frame cannot be blank, setting to default");
+    output_frame_ = kDefaultOutputFrame;
+  }
 
   nh_private_.param("rename_input_frame", rename_input_frame_,
                     kDefaultRenameInputFrame);
   nh_private_.param("left_input_frame", left_input_frame_,
                     kDefaultLeftInputFrame);
+  if (left_input_frame_ == "") {
+    ROS_ERROR("Left input frame cannot be blank, setting to default");
+    left_input_frame_ = kDefaultLeftInputFrame;
+  }
   nh_private_.param("right_input_frame", right_input_frame_,
                     kDefaultRightInputFrame);
+  if (right_input_frame_ == "") {
+    ROS_ERROR("Right input frame cannot be blank, setting to default");
+    right_input_frame_ = kDefaultRightInputFrame;
+  }
 
   // setup publishers
   left_camera_info_output_pub_ = nh_.advertise<sensor_msgs::CameraInfo>(
@@ -191,8 +203,8 @@ void StereoUndistort::processAndSendImage(
       cv_bridge::toCvShare(image_msg_in, output_image_type_);
 
   std::string encoding = image_in_ptr->encoding;
-  if(encoding == "8UC1"){
-    //ros does not recognize U8C1 and it will crash the disparity node
+  if (encoding == "8UC1") {
+    // ros does not recognize U8C1 and it will crash the disparity node
     encoding = "mono8";
   }
   cv_bridge::CvImagePtr image_out_ptr(

--- a/src/stereo_undistort.cpp
+++ b/src/stereo_undistort.cpp
@@ -64,7 +64,7 @@ StereoUndistort::StereoUndistort(const ros::NodeHandle& nh,
 
   nh_private_.param("publish_tf", publish_tf_, kDefaultPublishTF);
   nh_private_.param("output_frame", output_frame_, kDefaultOutputFrame);
-  if (output_frame_ == "") {
+  if (output_frame_.empty()) {
     ROS_ERROR("Output frame cannot be blank, setting to default");
     output_frame_ = kDefaultOutputFrame;
   }
@@ -73,13 +73,13 @@ StereoUndistort::StereoUndistort(const ros::NodeHandle& nh,
                     kDefaultRenameInputFrame);
   nh_private_.param("left_input_frame", left_input_frame_,
                     kDefaultLeftInputFrame);
-  if (left_input_frame_ == "") {
+  if (left_input_frame_.empty()) {
     ROS_ERROR("Left input frame cannot be blank, setting to default");
     left_input_frame_ = kDefaultLeftInputFrame;
   }
   nh_private_.param("right_input_frame", right_input_frame_,
                     kDefaultRightInputFrame);
-  if (right_input_frame_ == "") {
+  if (right_input_frame_.empty()) {
     ROS_ERROR("Right input frame cannot be blank, setting to default");
     right_input_frame_ = kDefaultRightInputFrame;
   }
@@ -237,7 +237,7 @@ void StereoUndistort::processAndSendImage(
       if (rename_input_frame_) {
         frame = left_input_frame_;
       }
-      if (frame == "") {
+      if (frame.empty()) {
         ROS_ERROR_ONCE("Image frame name is blank, cannot construct tf");
       } else {
         br_.sendTransform(tf::StampedTransform(tf::Transform(R_ros, p_ros),

--- a/src/undistorter.cpp
+++ b/src/undistorter.cpp
@@ -58,7 +58,6 @@ Undistorter::Undistorter(
 
 void Undistorter::undistortImage(const cv::Mat& image,
                                  cv::Mat* undistorted_image) {
-#if (defined(CV_VERSION_EPOCH) && CV_VERSION_EPOCH == 2)
   if (empty_pixels_) {
     cv::remap(image, *undistorted_image, map_x_, map_y_, cv::INTER_LINEAR,
               cv::BORDER_CONSTANT);
@@ -67,19 +66,6 @@ void Undistorter::undistortImage(const cv::Mat& image,
     cv::remap(image, *undistorted_image, map_x_, map_y_, cv::INTER_LINEAR,
               cv::BORDER_REPLICATE);
   }
-#else
-  cv::UMat gpu_image = image.getUMat(cv::ACCESS_READ);
-  cv::UMat gpu_undistorted_image;
-  if (empty_pixels_) {
-    cv::remap(gpu_image, gpu_undistorted_image, map_x_, map_y_,
-              cv::INTER_LINEAR, cv::BORDER_CONSTANT);
-  } else {
-    // replicate is more efficient for gpus to calculate
-    cv::remap(gpu_image, gpu_undistorted_image, map_x_, map_y_,
-              cv::INTER_LINEAR, cv::BORDER_REPLICATE);
-  }
-  gpu_undistorted_image.copyTo(*undistorted_image);
-#endif
 }
 
 const CameraParametersPair& Undistorter::getCameraParametersPair() {


### PR DESCRIPTION
@mfehr 
- Previously parameters were being feed to nodlets incorrectly. This prevented the use of approximate_sync which is needed on some datasets.

- added ability to override input frames of images and print warnings on empty frames

- nodes now check for encoding "8UC1" and rename it to "mono8" as the former will crash roses image conversion functions.

- also removed use of UMats as it seems opencv will still use them internally