### PR TITLE
Fix/proper angle adjust

### DIFF
--- a/include/image_undistort/undistorter.h
+++ b/include/image_undistort/undistorter.h
@@ -26,7 +26,8 @@ class Undistorter {
   static void setOptimalOutputCameraParameters(
       const double scale, CameraParametersPair* camera_parameters_pair);
 
-  static void distortPixel(const Eigen::Matrix<double, 3, 4>& P_in,
+  static void distortPixel(const Eigen::Matrix<double, 3, 3>& K_in,
+                           const Eigen::Matrix<double, 3, 3>& R_in,
                            const Eigen::Matrix<double, 3, 4>& P_out,
                            const DistortionModel& distortion_model,
                            const std::vector<double>& D,

--- a/src/camera_parameters.cpp
+++ b/src/camera_parameters.cpp
@@ -361,7 +361,7 @@ bool CameraParametersPair::setOptimalOutputCameraParameters(
     double max_y = 0;
     for (Eigen::Vector2d pixel_location : pixel_locations) {
       Eigen::Vector2d distorted_pixel_location;
-      Undistorter::distortPixel(input_ptr_->P(), P,
+      Undistorter::distortPixel(input_ptr_->K(), input_ptr_->R(), P,
                                 input_ptr_->distortionModel(), D,
                                 pixel_location, &distorted_pixel_location);
 
@@ -573,47 +573,24 @@ bool StereoCameraParameters::generateRectificationParameters() {
   Eigen::Vector3d y = first_.getInputPtr()->R().col(2).cross(x);
   Eigen::Vector3d z = x.cross(y);
 
-  Eigen::Matrix3d R;
-  R << x.normalized(), y.normalized(), z.normalized();
-
-  
-  bool first_is_left = true;
+  Eigen::Matrix4d T = Eigen::Matrix4d::Identity();
+  T.topLeftCorner<3, 3>() << x.normalized(), y.normalized(), z.normalized();
 
   // took wrong camera as left (redo other way round)
-  if (R(0, 0) < 0) {
-    first_is_left = false;
+  if (T(0, 0) < 0) {
     x = second_.getInputPtr()->p() - first_.getInputPtr()->p();
     y = second_.getInputPtr()->R().col(2).cross(x);
     z = x.cross(y);
-    R << x.normalized(), y.normalized(), z.normalized();
-
-  } 
-
-  //now we have the angle we have to halve it
-  Eigen::AngleAxisd R_angle_axis(R);
-  R_angle_axis.angle() /= 2.0;
-  R = R_angle_axis;
-
-  Eigen::Matrix4d T_first = Eigen::Matrix4d::Identity();
-  Eigen::Matrix4d T_second = Eigen::Matrix4d::Identity();
-  
-  if(first_is_left){
-    T_first.topLeftCorner<3,3>() = R.inverse() * first_.getInputPtr()->R();
-    T_second.topLeftCorner<3,3>() = R * second_.getInputPtr()->R();
-    T_first(0,3) = x.norm();
-  } else {
-    T_second.topLeftCorner<3,3>() = R.inverse() * second_.getInputPtr()->R();
-    T_first.topLeftCorner<3,3>() = R * first_.getInputPtr()->R();
-    T_second(0,3) = x.norm();
+    T.topLeftCorner<3, 3>() << x.normalized(), y.normalized(), z.normalized();
   }
 
   first_.setInputCameraParameters(
       first_.getInputPtr()->resolution(),
-      T_first, first_.getInputPtr()->K(),
+      T.inverse() * first_.getInputPtr()->T(), first_.getInputPtr()->K(),
       first_.getInputPtr()->D(), first_.getInputPtr()->distortionModel());
   second_.setInputCameraParameters(
       second_.getInputPtr()->resolution(),
-      T_second, second_.getInputPtr()->K(),
+      T.inverse() * second_.getInputPtr()->T(), second_.getInputPtr()->K(),
       second_.getInputPtr()->D(), second_.getInputPtr()->distortionModel());
 
   // set individual outputs


### PR DESCRIPTION
Okay I know I have said this before but I think I have finally fixed the distorted depth.
What I was looking at last time was the right symptom but the complete wrong fix.

What was actually going on was two issues
- I was performing the rotation in the distorted image
- I wasn't compensating for the change in z the rotation caused

These effects seem to become a lot more noticeable when the principle point is far from the center of the image, which I believe is why we were only seeing this with the downward pair. @marco-tranzatto @alexmillane 

![screenshot from 2017-06-22 10-04-47](https://user-images.githubusercontent.com/730680/27423540-4707ca42-5732-11e7-9455-739cc9cd0bb6.png)
