### PR TITLE
added point to bearing method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.clang_complete

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ project(image_undistort)
 set(CMAKE_CXX_FLAGS "-std=c++11 -Ofast")
 
 find_package(Eigen3 REQUIRED)
-find_package(nlopt REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   roslib
@@ -16,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   image_transport
   tf_conversions
   nodelet
+  nlopt
 )
 
 catkin_package(
@@ -45,7 +45,7 @@ add_library(${PROJECT_NAME}_nodelet
   src/point_to_bearing.cpp)
 
 target_link_libraries(${PROJECT_NAME}_nodelet
-  ${catkin_LIBRARIES} ${nlopt_LIBRARIES}
+  ${catkin_LIBRARIES}
 )
 add_dependencies(${PROJECT_NAME}_nodelet ${catkin_EXPORTED_TARGETS})
 
@@ -76,7 +76,7 @@ target_link_libraries(dense_stereo_node
 
 add_executable(point_to_bearing_node src/nodes/point_to_bearing_node.cpp)
 target_link_libraries(point_to_bearing_node
-  ${catkin_LIBRARIES} ${nlopt_LIBRARIES}
+  ${catkin_LIBRARIES}
 )
 
 # Install nodelet library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(image_undistort)
 set(CMAKE_CXX_FLAGS "-std=c++11 -Ofast")
 
 find_package(Eigen3 REQUIRED)
+find_package(nlopt REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   roslib
@@ -25,6 +26,7 @@ catkin_package(
 include_directories(
   include
   ${EIGEN3_INCLUDE_DIR}
+  ${nlopt_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
 )
 
@@ -33,15 +35,17 @@ add_library(${PROJECT_NAME}_nodelet
   src/nodelets/stereo_info_nodelet.cpp
   src/nodelets/stereo_undistort_nodelet.cpp
   src/nodelets/depth_nodelet.cpp
+  src/nodelets/point_to_bearing_nodelet.cpp
   src/stereo_info.cpp
   src/stereo_undistort.cpp
   src/depth.cpp
   src/camera_parameters.cpp 
   src/image_undistort.cpp 
-  src/undistorter.cpp)
+  src/undistorter.cpp
+  src/point_to_bearing.cpp)
 
 target_link_libraries(${PROJECT_NAME}_nodelet
-  ${catkin_LIBRARIES}
+  ${catkin_LIBRARIES} ${nlopt_LIBRARIES}
 )
 add_dependencies(${PROJECT_NAME}_nodelet ${catkin_EXPORTED_TARGETS})
 
@@ -52,7 +56,7 @@ target_link_libraries(image_undistort_node
 
 add_executable(stereo_info_node src/nodes/stereo_info_node.cpp)
 target_link_libraries(stereo_info_node
-  ${catkin_LIBRARIES}
+  ${catkin_LIBRARIES} 
 )
 
 add_executable(stereo_undistort_node src/nodes/stereo_undistort_node.cpp)
@@ -68,6 +72,11 @@ target_link_libraries(depth_node
 add_executable(dense_stereo_node src/nodes/dense_stereo_node.cpp)
 target_link_libraries(dense_stereo_node
   ${catkin_LIBRARIES}
+)
+
+add_executable(point_to_bearing_node src/nodes/point_to_bearing_node.cpp)
+target_link_libraries(point_to_bearing_node
+  ${catkin_LIBRARIES} ${nlopt_LIBRARIES}
 )
 
 # Install nodelet library

--- a/include/image_undistort/point_to_bearing.h
+++ b/include/image_undistort/point_to_bearing.h
@@ -1,0 +1,62 @@
+#ifndef IMAGE_UNDISTORT_POINT_TO_BEARING_NODELET_H
+#define IMAGE_UNDISTORT_POINT_TO_BEARING_NODELET_H
+
+#include <stdio.h>
+#include <Eigen/Dense>
+
+#include <nodelet/nodelet.h>
+#include <ros/callback_queue.h>
+#include <ros/ros.h>
+
+#include <geometry_msgs/PointStamped.h>
+#include <sensor_msgs/CameraInfo.h>
+
+#include <nlopt.hpp>
+
+#include "image_undistort/undistorter.h"
+
+namespace image_undistort {
+
+// Default values
+
+// queue size
+constexpr int kQueueSize = 10;
+// true to load cam_info from ros parameters, false to get it from a
+// cam_info topic
+constexpr bool kDefaultCameraInfoFromROSParams = false;
+// namespace to use when loading camera parameters from ros params
+const std::string kDefaultCameraNamespace = "camera";
+
+class PointToBearing {
+ public:
+  PointToBearing(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+
+  static double bearingProjectionError(const std::vector<double>& values,
+                                       std::vector<double>& grad, void* data);
+
+ private:
+  void imagePointCallback(
+      const geometry_msgs::PointStampedConstPtr& image_point);
+
+  void cameraInfoCallback(const sensor_msgs::CameraInfoConstPtr& camera_info);
+
+  // nodes
+  ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+
+  // subscribers
+  ros::Subscriber camera_info_sub_;
+  ros::Subscriber image_point_sub_;
+
+  // publishers
+  ros::Publisher bearing_pub_;
+
+  // camera info
+  std::shared_ptr<InputCameraParameters> camera_parameters_ptr_;
+
+  // other variables
+  int queue_size_;
+};
+}
+
+#endif

--- a/include/image_undistort/point_to_bearing.h
+++ b/include/image_undistort/point_to_bearing.h
@@ -31,6 +31,10 @@ class PointToBearing {
  public:
   PointToBearing(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
 
+  static void optimizeForBearingVector(
+      const InputCameraParameters& camera_parameters,
+      const Eigen::Vector2d& pixel_location, Eigen::Vector3d* bearing);
+
   static double bearingProjectionError(const std::vector<double>& values,
                                        std::vector<double>& grad, void* data);
 

--- a/launch/basic_undistort_example.launch
+++ b/launch/basic_undistort_example.launch
@@ -1,0 +1,15 @@
+<launch>
+
+<arg name="input_camera_name" default="cam0" />
+<arg name="scale" default="1.0" />
+<arg name="calib_path" default="/home/z/Datasets/euroc/camchain.yaml"/>
+
+  <node name="image_undistort_node" pkg="image_undistort" type="image_undistort_node">
+    <param name="input_camera_namespace" value="cam1"/>      
+    <param name="input_camera_info_from_ros_params" value = "true"/>    
+    <param name="scale" value="$(arg scale)"/>
+    <rosparam file="$(arg calib_path)"/>
+    <remap from="input/image" to="$(arg input_camera_name)/image_raw"/>
+  </node>
+
+</launch>

--- a/launch/disparity.launch
+++ b/launch/disparity.launch
@@ -1,0 +1,15 @@
+<launch>
+
+<arg name="first_camera_name" default="cam00" />
+<arg name="second_camera_name" default="cam01" />
+<arg name="play_bag" value="true" />
+<arg name="bag_file" value="/home/z/Datasets/KITTI/2011_09_26/2011_09_26_drive_0035_sync/data.bag"/>
+
+<node name="depth_node" pkg="image_undistort" type="depth_node">
+    <remap from="rect/first/image" to="$(arg first_camera_name)/image_raw"/>
+    <remap from="rect/second/image" to="$(arg second_camera_name)/image_raw"/>
+    <remap from="rect/first/camera_info" to="$(arg first_camera_name)/camera_info"/>
+    <remap from="rect/second/camera_info" to="$(arg second_camera_name)/camera_info"/>
+</node>
+
+</launch>

--- a/launch/euroc_dataset_example.launch
+++ b/launch/euroc_dataset_example.launch
@@ -1,0 +1,25 @@
+<launch>
+
+<arg name="first_camera_name" default="cam0" />
+<arg name="second_camera_name" default="cam1" />
+<arg name="scale" default="1.0" />
+<arg name="process_every_nth_frame" default="1" />
+<arg name="stereo_params_camchain" default="/home/z/catkin_ws/src/mav_tools/mav_startup/parameters/mavs/ibis/camchain_p23023.yaml"/>
+
+
+
+  <node name="stereo_undistort" pkg="image_undistort" type="stereo_undistort_node">
+    <param name="input_camera_info_from_ros_params" value = "true"/>
+    <param name="first_camera_namespace" value="$(arg first_camera_name)"/>
+    <param name="second_camera_namespace" value="$(arg second_camera_name)"/>
+    <param name="scale" value="$(arg scale)"/>
+    <param name="process_every_nth_frame" value="$(arg process_every_nth_frame)"/>
+    
+    <rosparam file="$(arg stereo_params_camchain)"/>
+
+    <remap from="raw/first/image" to="$(arg first_camera_name)/image_raw"/>
+    <remap from="raw/second/image" to="$(arg second_camera_name)/image_raw"/>
+  </node>
+
+
+</launch>

--- a/launch/ibis_voxblox_example.launch
+++ b/launch/ibis_voxblox_example.launch
@@ -1,0 +1,50 @@
+<launch>
+
+<arg name="mav_name" default="ibis" />
+<arg name="namespace" default="$(arg mav_name)" />
+<arg name="process_every_nth_frame" default="1" />
+<arg name="play_bag" value="true" />
+<arg name="stereo_params_camchain" default="$(find mav_startup)/parameters/mavs/ibis/camchain_p22031.yaml"/>
+<arg name="bag_file" value="/home/z/Datasets/2017-05-23-honggerberg/ibis-erl-2017-06-16-11-54-43.bag"/>  
+
+<node name="player" pkg="rosbag" type="play" output="screen" args="  -r 0.5 --clock $(arg bag_file)"  if="$(arg play_bag)"/>
+
+<group ns="$(arg namespace)">
+ 
+    <node name="dense_stereo" pkg="image_undistort" type="dense_stereo_node">
+      <param name="input_camera_info_from_ros_params" value = "true"/>
+      <param name="first_camera_namespace" value="cam2"/>
+      <param name="second_camera_namespace" value="cam3"/>
+      <param name="first_output_frame" value="cam2_rect"/>
+      <param name="second_output_frame" value="cam3_rect"/>
+      <param name="scale" value="1.0"/>
+      <param name="rename_radtan_plumb_bob" value="true"/>
+      <param name="process_every_nth_frame" value="$(arg process_every_nth_frame)"/>
+
+      <rosparam file="$(arg stereo_params_camchain)"/>
+  
+      <remap from="raw/first/image" to="cam2/image_raw"/>
+      <remap from="raw/second/image" to="cam3/image_raw"/>
+      <remap from="raw/first/camera_info" to="cam2/camera_info"/>
+      <remap from="raw/second/camera_info" to="cam3/camera_info"/>
+    </node>
+
+  <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
+    <remap from="pointcloud" to="dense_stereo/pointcloud"/>
+    <remap from="freespace_pointcloud" to="dense_stereo/reespace_pointcloud"/>
+    <param name="tsdf_voxel_size" value="0.05" />
+    <param name="tsdf_voxels_per_side" value="16" />
+    <param name="voxel_carving_enabled" value="true" />
+    <param name="color_mode" value="colors" />
+    <param name="max_ray_length_m" value="5.0" />
+    <param name="use_tf_transforms" value="true" />
+    <param name="verbose" value="true" />
+    <param name="world_frame" value="arena"/>
+    <param name="update_mesh_every_n_sec" value="0.5" />
+    <param name="generate_esdf" value="false" />
+    <param name="method" value="merged" />
+    <param name="use_const_weight" value="false" />
+  </node>
+</group>
+
+</launch>

--- a/launch/kitti_depth_example.launch
+++ b/launch/kitti_depth_example.launch
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="ISO-8859-15"?>
+<launch>
+
+<arg name="first_camera_name" default="cam00" />
+<arg name="second_camera_name" default="cam01" />
+<arg name="play_bag" value="true" />
+<arg name="bag_file" value="/home/z/Datasets/KITTI/2011_09_26/2011_09_26_drive_0035_sync/data.bag"/>  
+
+<node name="player" pkg="rosbag" type="play" output="screen" args=" --clock $(arg bag_file)"  if="$(arg play_bag)"/>
+
+<node name="depth_node" pkg="image_undistort" type="depth_node">
+    <remap from="rect/first/image" to="$(arg first_camera_name)/image_raw"/>
+    <remap from="rect/second/image" to="$(arg second_camera_name)/image_raw"/>
+    <remap from="rect/first/camera_info" to="$(arg first_camera_name)/camera_info"/>
+    <remap from="rect/second/camera_info" to="$(arg second_camera_name)/camera_info"/>
+</node>
+
+<node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
+  <remap from="pointcloud" to="/pointcloud"/>
+  <remap from="freespace_pointcloud" to="/freespace_pointcloud"/>
+  <param name="use_freespace_pointcloud" value="true"/>
+  <param name="tsdf_voxel_size" value="0.2" />
+  <param name="tsdf_voxels_per_side" value="16" />
+  <param name="voxel_carving_enabled" value="true" />
+  <param name="color_mode" value="colors" />
+  <param name="max_ray_length_m" value="30.0" />
+  <param name="use_tf_transforms" value="true" />
+  <param name="verbose" value="true" />
+  <param name="world_frame" value="world"/>
+  <param name="output_mesh_as_pcl_mesh" value="true"/>
+  <param name="update_mesh_every_n_sec" value="1" />
+  <param name="mesh_filename" value="/home/z/Desktop/mesh.ply" />
+  <param name="generate_esdf" value="false" />
+  <param name="method" value="merged" />
+  <param name="use_const_weight" value="false" />
+</node>
+
+</launch>

--- a/nodelet_plugins.xml
+++ b/nodelet_plugins.xml
@@ -19,4 +19,9 @@
       Depth nodelet
     </description>
   </class>
+  <class name="image_undistort/PointToBearingNodelet" type="image_undistort::PointToBearingNodelet" base_class_type="nodelet::Nodelet">
+    <description>
+      Point to bearing nodelet
+    </description>
+  </class>
 </library>

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <depend>image_transport</depend>
   <depend>tf_conversions</depend>
   <depend>nodelet</depend>
+  <depend>nlopt</depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />

--- a/src/nodelets/point_to_bearing_nodelet.cpp
+++ b/src/nodelets/point_to_bearing_nodelet.cpp
@@ -1,0 +1,24 @@
+#include <nodelet/nodelet.h>
+#include <pluginlib/class_list_macros.h>
+
+#include "image_undistort/point_to_bearing.h"
+
+namespace image_undistort {
+
+class PointToBearingNodelet : public nodelet::Nodelet {
+  virtual void onInit() {
+    try {
+      point_to_bearing_ = std::make_shared<PointToBearing>(
+          getNodeHandle(), getPrivateNodeHandle());
+    } catch (std::runtime_error e) {
+      ROS_ERROR("%s", e.what());
+    }
+  }
+
+  std::shared_ptr<PointToBearing> point_to_bearing_;
+};
+}
+
+PLUGINLIB_DECLARE_CLASS(image_undistort, PointToBearingNodelet,
+                        image_undistort::PointToBearingNodelet,
+                        nodelet::Nodelet);

--- a/src/nodes/point_to_bearing_node.cpp
+++ b/src/nodes/point_to_bearing_node.cpp
@@ -1,0 +1,15 @@
+#include <nodelet/loader.h>
+#include <ros/ros.h>
+
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "point_to_bearing_node");
+  nodelet::Loader nodelet;
+  nodelet::M_string remap(ros::names::getRemappings());
+  nodelet::V_string nargv;
+  std::string nodelet_name = ros::this_node::getName();
+  ROS_INFO_STREAM("Started " << nodelet_name << " nodelet.");
+  nodelet.load(nodelet_name, "image_undistort/PointToBearingNodelet", remap,
+               nargv);
+  ros::spin();
+  return 0;
+}

--- a/src/point_to_bearing.cpp
+++ b/src/point_to_bearing.cpp
@@ -1,0 +1,119 @@
+#include "image_undistort/point_to_bearing.h"
+#include "image_undistort/camera_parameters.h"
+#include "image_undistort/undistorter.h"
+
+namespace image_undistort {
+
+PointToBearing::PointToBearing(const ros::NodeHandle& nh,
+                               const ros::NodeHandle& nh_private)
+    : nh_(nh), nh_private_(nh_private) {
+  // set parameters from ros
+  bool camera_info_from_ros_params;
+  nh_private_.param("camera_info_from_ros_params", camera_info_from_ros_params,
+                    kDefaultCameraInfoFromROSParams);
+
+  nh_private_.param("queue_size", queue_size_, kQueueSize);
+  if (queue_size_ < 1) {
+    ROS_ERROR("Queue size must be >= 1, setting to 1");
+    queue_size_ = 1;
+  }
+
+  // setup subscribers
+  std::string camera_namespace;
+  if (camera_info_from_ros_params) {
+    nh_private_.param("camera_namespace", camera_namespace,
+                      kDefaultCameraNamespace);
+
+    try {
+      camera_parameters_ptr_ = std::make_shared<InputCameraParameters>(
+          nh_private_, camera_namespace);
+    } catch (std::runtime_error e) {
+      ROS_ERROR("%s", e.what());
+      ROS_FATAL("Loading of input camera parameters failed, exiting");
+      ros::shutdown();
+      exit(EXIT_FAILURE);
+    }
+
+  } else {
+    camera_info_sub_ = nh_.subscribe("camera_info", queue_size_,
+                                     &PointToBearing::cameraInfoCallback, this);
+  }
+
+  image_point_sub_ = nh_.subscribe("image_point", queue_size_,
+                                   &PointToBearing::imagePointCallback, this);
+
+  // setup publishers
+  bearing_pub_ =
+      nh_.advertise<geometry_msgs::PointStamped>("bearing", queue_size_);
+}
+
+void PointToBearing::imagePointCallback(
+    const geometry_msgs::PointStampedConstPtr& image_point) {
+  if (camera_parameters_ptr_ == nullptr) {
+    ROS_WARN("No camera calibration, cannot calculate bearing");
+    return;
+  }
+
+  const Eigen::Vector2d inital_guess =
+      (camera_parameters_ptr_->P().topLeftCorner<3, 3>().inverse() *
+       Eigen::Vector3d(image_point->point.x, image_point->point.y, 1.0))
+          .head<2>();
+  const Eigen::Vector2d pixel_location(image_point->point.x,
+                                       image_point->point.y);
+  std::pair<const Eigen::Vector2d&, const InputCameraParameters&> data_pair =
+      std::make_pair(pixel_location, *camera_parameters_ptr_);
+
+  nlopt::opt opt(nlopt::LN_NELDERMEAD, 2);
+
+  opt.set_min_objective(PointToBearing::bearingProjectionError,
+                        static_cast<void*>(&data_pair));
+  opt.set_xtol_rel(1e-3);
+
+  std::vector<double> values = {inital_guess.x(), inital_guess.y()};
+  double minf;
+  nlopt::result result = opt.optimize(values, minf);
+
+  Eigen::Vector3d bearing(values[0], values[1], 1.0);
+  bearing.normalize();
+  geometry_msgs::PointStamped bearing_msg;
+  bearing_msg.header = image_point->header;
+  bearing_msg.point.x = bearing.x();
+  bearing_msg.point.y = bearing.y();
+  bearing_msg.point.z = bearing.z();
+  bearing_pub_.publish(bearing_msg);
+}
+
+double PointToBearing::bearingProjectionError(const std::vector<double>& values,
+                              std::vector<double>& grad, void* data) {
+  // split out inputs
+  const Eigen::Vector2d pixel_location(values[0], values[1]);
+  const std::pair<const Eigen::Vector2d&, const InputCameraParameters&>
+      data_pair = *static_cast<
+          std::pair<const Eigen::Vector2d&, const InputCameraParameters&>*>(
+          data);
+  const Eigen::Vector2d& distorted_pixel_location = data_pair.first;
+  const InputCameraParameters& camera_parameters = data_pair.second;
+
+  Eigen::Matrix<double, 3, 4> P_bearing;
+  P_bearing.topLeftCorner<3, 3>() = Eigen::Matrix3d::Identity();
+  P_bearing.topRightCorner<3, 1>() = Eigen::Vector3d::Zero();
+
+  Eigen::Vector2d estimated_distorted_pixel_location;
+  Undistorter::distortPixel(camera_parameters.K(), camera_parameters.R(),
+                            P_bearing, camera_parameters.distortionModel(),
+                            camera_parameters.D(), pixel_location,
+                            &estimated_distorted_pixel_location);
+
+  return (estimated_distorted_pixel_location - distorted_pixel_location).norm();
+}
+
+void PointToBearing::cameraInfoCallback(
+    const sensor_msgs::CameraInfoConstPtr& camera_info) {
+  try {
+    camera_parameters_ptr_ =
+        std::make_shared<InputCameraParameters>(*camera_info);
+  } catch (std::runtime_error e) {
+    ROS_ERROR("%s", e.what());
+  }
+}
+}

--- a/src/point_to_bearing.cpp
+++ b/src/point_to_bearing.cpp
@@ -54,14 +54,30 @@ void PointToBearing::imagePointCallback(
     return;
   }
 
-  const Eigen::Vector2d inital_guess =
-      (camera_parameters_ptr_->P().topLeftCorner<3, 3>().inverse() *
-       Eigen::Vector3d(image_point->point.x, image_point->point.y, 1.0))
-          .head<2>();
   const Eigen::Vector2d pixel_location(image_point->point.x,
                                        image_point->point.y);
+
+  Eigen::Vector3d bearing;
+  optimizeForBearingVector(*camera_parameters_ptr_, pixel_location, &bearing);
+
+  geometry_msgs::PointStamped bearing_msg;
+  bearing_msg.header = image_point->header;
+  bearing_msg.point.x = bearing.x();
+  bearing_msg.point.y = bearing.y();
+  bearing_msg.point.z = bearing.z();
+  bearing_pub_.publish(bearing_msg);
+}
+
+void PointToBearing::optimizeForBearingVector(
+    const InputCameraParameters& camera_parameters,
+    const Eigen::Vector2d& pixel_location, Eigen::Vector3d* bearing) {
+  const Eigen::Vector2d inital_guess =
+      (camera_parameters.P().topLeftCorner<3, 3>().inverse() *
+       Eigen::Vector3d(pixel_location[0], pixel_location[1], 1.0))
+          .head<2>();
+
   std::pair<const Eigen::Vector2d&, const InputCameraParameters&> data_pair =
-      std::make_pair(pixel_location, *camera_parameters_ptr_);
+      std::make_pair(pixel_location, camera_parameters);
 
   nlopt::opt opt(nlopt::LN_NELDERMEAD, 2);
 
@@ -73,14 +89,8 @@ void PointToBearing::imagePointCallback(
   double minf;
   nlopt::result result = opt.optimize(values, minf);
 
-  Eigen::Vector3d bearing(values[0], values[1], 1.0);
-  bearing.normalize();
-  geometry_msgs::PointStamped bearing_msg;
-  bearing_msg.header = image_point->header;
-  bearing_msg.point.x = bearing.x();
-  bearing_msg.point.y = bearing.y();
-  bearing_msg.point.z = bearing.z();
-  bearing_pub_.publish(bearing_msg);
+  *bearing = Eigen::Vector3d(values[0], values[1], 1.0);
+  bearing->normalize();
 }
 
 double PointToBearing::bearingProjectionError(const std::vector<double>& values,

--- a/src/undistorter.cpp
+++ b/src/undistorter.cpp
@@ -80,7 +80,7 @@ void Undistorter::distortPixel(const Eigen::Matrix<double, 3, 3>& K_in,
                                const std::vector<double>& D,
                                const Eigen::Vector2d& pixel_location,
                                Eigen::Vector2d* distorted_pixel_location) {
-  Eigen::Vector3d pixel_location_3(pixel_location.x(), pixel_location.y(), 1);
+  Eigen::Vector3d pixel_location_3(pixel_location.x(), pixel_location.y(), 1.0);
 
   // Transform image coordinates to be size and focus independent
   Eigen::Vector3d norm_pixel_location =
@@ -89,7 +89,7 @@ void Undistorter::distortPixel(const Eigen::Matrix<double, 3, 3>& K_in,
   const double& x = norm_pixel_location.x();
   const double& y = norm_pixel_location.y();
 
-  Eigen::Vector3d norm_distorted_pixel_location(0, 0, norm_pixel_location.z());
+  Eigen::Vector3d norm_distorted_pixel_location(0.0, 0.0, norm_pixel_location.z());
   double& xd = norm_distorted_pixel_location.x();
   double& yd = norm_distorted_pixel_location.y();
 


### PR DESCRIPTION
Added a nodelet/node that you give a image pixel location (takes a PointStamped but the z is ignored) and outputs a bearing vector. Currently done by a topic, but could make a service call.

Also if you need tighter integration with the person detector, you could add image_undistort as a library, then have functions very similar to those in src/point_to_bearing.cpp

Still relatively untested, but the concept is there.