### PR TITLE
added sgbm parameters

### DIFF
--- a/include/image_undistort/depth.h
+++ b/include/image_undistort/depth.h
@@ -26,17 +26,26 @@ namespace image_undistort {
 constexpr int kQueueSize = 10;
 // small number used to check things are approximately equal
 constexpr double kDelta = 0.000000001;
-// stereobm parameters
-const std::string kPreFilterType = "xsobel";
-constexpr int kPreFilterSize = 9;
+// stereo parameters
 constexpr int kPreFilterCap = 31;
 constexpr int kSADWindowSize = 11;
 constexpr int kMinDisparity = 0;
 constexpr int kNumDisparities = 64;
-constexpr int kTextureThreshold = 0;
 constexpr int kUniquenessRatio = 0;
 constexpr int kSpeckleRange = 3;
 constexpr int kSpeckleWindowSize = 500;
+// bm parameters
+constexpr int kTextureThreshold = 0;
+const std::string kPreFilterType = "xsobel";
+constexpr int kPreFilterSize = 9;
+// sgbm parameters
+constexpr bool kUseSGBM = false;
+constexpr int kP1 = 120;
+constexpr int kP2 = 240;
+constexpr int kDisp12MaxDiff = -1;
+constexpr bool kUseHHMode = false;
+
+constexpr bool kDoMedianBlur = true;
 
 class Depth {
  public:
@@ -102,17 +111,28 @@ class Depth {
       CameraSyncPolicy;
   message_filters::Synchronizer<CameraSyncPolicy> camera_sync_;
 
-  // stereobm parameters
-  int pre_filter_type_;
-  int pre_filter_size_;
+  // stereo parameters
   int pre_filter_cap_;
   int sad_window_size_;
   int min_disparity_;
   int num_disparities_;
-  int texture_threshold_;
   int uniqueness_ratio_;
   int speckle_range_;
   int speckle_window_size_;
+
+  // bm parameters
+  int texture_threshold_;
+  int pre_filter_type_;
+  int pre_filter_size_;
+
+  // sgbm parameters
+  bool use_sgbm_;
+  int p1_, kP1;
+  int p2_, kP2;
+  int disp_12_max_diff_;
+  bool use_mode_HH_;
+
+  bool do_median_blur_;
 };
 }
 

--- a/include/image_undistort/depth.h
+++ b/include/image_undistort/depth.h
@@ -127,8 +127,8 @@ class Depth {
 
   // sgbm parameters
   bool use_sgbm_;
-  int p1_, kP1;
-  int p2_, kP2;
+  int p1_;
+  int p2_;
   int disp_12_max_diff_;
   bool use_mode_HH_;
 

--- a/launch/dense_stereo.launch
+++ b/launch/dense_stereo.launch
@@ -2,7 +2,6 @@
 
 <arg name="mav_name" default="ibis" />
 <arg name="namespace" default="$(arg mav_name)" />
-<arg name="scale" default="0.75" />
 <arg name="process_every_nth_frame" default="1" />
 <arg name="stereo_params_camchain" default="$(find mav_startup)/parameters/mavs/ibis/camchain_p22031.yaml"/>
 
@@ -14,9 +13,11 @@
       <param name="second_camera_namespace" value="cam1"/>
       <param name="first_output_frame" value="cam0_rect"/>
       <param name="second_output_frame" value="cam1_rect"/>
-      <param name="scale" value="0.5"/>
+      <param name="scale" value="1.0"/>
       <param name="process_every_nth_frame" value="$(arg process_every_nth_frame)"/>
-
+      <param name="depth/use_sgbm" value="true"/>
+      <param name="depth/do_median_blur" value="false"/>
+      <param name="depth/use_mode_HH" value="true"/>
       <rosparam file="$(arg stereo_params_camchain)"/>
   
       <remap from="raw/first/image" to="/$(arg mav_name)/cam0/image_raw"/>
@@ -24,24 +25,6 @@
       <remap from="raw/first/camera_info" to="/$(arg mav_name)/cam0/camera_info"/>
       <remap from="raw/second/camera_info" to="/$(arg mav_name)/cam1/camera_info"/>
     </node>
-
-  <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
-    <remap from="pointcloud" to="dense_stereo/pointcloud"/>
-    <remap from="freespace_pointcloud" to="dense_stereo/freespace_pointcloud"/>
-    <param name="tsdf_voxel_size" value="0.1" />
-    <param name="tsdf_voxels_per_side" value="16" />
-    <param name="truncation_distance" value="0.4" />
-    <param name="voxel_carving_enabled" value="true" />
-    <param name="color_mode" value="colors" />
-    <param name="max_ray_length_m" value="10.0" />
-    <param name="use_tf_transforms" value="true" />
-    <param name="verbose" value="true" />
-    <param name="world_frame" value="arena"/>
-    <param name="update_mesh_every_n_sec" value="0.5" />
-    <param name="generate_esdf" value="false" />
-    <param name="method" value="merged" />
-    <param name="use_const_weight" value="false" />
-  </node>
 </group>
 
 </launch>

--- a/src/depth.cpp
+++ b/src/depth.cpp
@@ -256,17 +256,17 @@ void Depth::calcDisparityImage(
     std::shared_ptr<cv::StereoSGBM> left_matcher =
         std::make_shared<cv::StereoSGBM>();
 
-    left_matcher->state->numberOfDisparities = num_disparities_;
-    left_matcher->state->BlockSize = sad_window_size_;
-    left_matcher->state->preFilterCap = pre_filter_cap_;
-    left_matcher->state->minDisparity = min_disparity_;
-    left_matcher->state->uniquenessRatio = uniqueness_ratio_;
-    left_matcher->state->speckleRange = speckle_range_;
-    left_matcher->state->speckleWindowSize = speckle_window_size_;
-    left_matcher->state->P1 = p1_;
-    left_matcher->state->P2 = p2_;
-    left_matcher->state->disp12MaxDiff = disp_12_max_diff_;
-    left_matcher->state->fullDP = use_mode_HH_;
+    left_matcher->numberOfDisparities = num_disparities_;
+    left_matcher->BlockSize = sad_window_size_;
+    left_matcher->preFilterCap = pre_filter_cap_;
+    left_matcher->minDisparity = min_disparity_;
+    left_matcher->uniquenessRatio = uniqueness_ratio_;
+    left_matcher->speckleRange = speckle_range_;
+    left_matcher->speckleWindowSize = speckle_window_size_;
+    left_matcher->P1 = p1_;
+    left_matcher->P2 = p2_;
+    left_matcher->disp12MaxDiff = disp_12_max_diff_;
+    left_matcher->fullDP = use_mode_HH_;
     left_matcher->operator()(left_ptr->image, right_ptr->image,
                              disparity_ptr->image);
   } else {

--- a/src/depth.cpp
+++ b/src/depth.cpp
@@ -257,7 +257,7 @@ void Depth::calcDisparityImage(
         std::make_shared<cv::StereoSGBM>();
 
     left_matcher->numberOfDisparities = num_disparities_;
-    left_matcher->BlockSize = sad_window_size_;
+    left_matcher->SADWindowSize = sad_window_size_;
     left_matcher->preFilterCap = pre_filter_cap_;
     left_matcher->minDisparity = min_disparity_;
     left_matcher->uniquenessRatio = uniqueness_ratio_;


### PR DESCRIPTION
Added sgbm, exposed parameters and made the median filter toggle-able.

If you want to set parameters while running the dense_stereo_node you need to add "depth/" to the front, for example:

param name="depth/use_sgbm" value="true"
param name="depth/do_median_blur" value="false"
param name="depth/use_mode_HH" value="true"