### PR TITLE
Fix multiple definitions of kQueue when using as library.

### DIFF
--- a/include/image_undistort/depth.h
+++ b/include/image_undistort/depth.h
@@ -23,7 +23,7 @@ namespace image_undistort {
 // Default values
 
 // queue size
-constexpr int kQueueSize = 10;
+constexpr int kDepthQueueSize = 10;
 // small number used to check things are approximately equal
 constexpr double kDelta = 0.000000001;
 // stereo parameters

--- a/include/image_undistort/image_undistort.h
+++ b/include/image_undistort/image_undistort.h
@@ -22,7 +22,7 @@ namespace image_undistort {
 // Default values
 
 // queue size
-constexpr int kQueueSize = 10;
+constexpr int kImageQueueSize = 10;
 // true to load input cam_info from ros parameters, false to get it from a
 // cam_info topic
 constexpr bool kDefaultInputCameraInfoFromROSParams = false;

--- a/src/depth.cpp
+++ b/src/depth.cpp
@@ -5,7 +5,7 @@ namespace image_undistort {
 // needed so that topic filters can be initialized in the constructor
 int Depth::getQueueSize() const {
   int queue_size;
-  nh_private_.param("queue_size", queue_size, kQueueSize);
+  nh_private_.param("queue_size", queue_size, kDepthQueueSize);
   if (queue_size < 1) {
     ROS_ERROR("Queue size must be >= 1, setting to 1");
     queue_size = 1;

--- a/src/image_undistort.cpp
+++ b/src/image_undistort.cpp
@@ -39,7 +39,7 @@ ImageUndistort::ImageUndistort(const ros::NodeHandle& nh,
     output_camera_info_source_ = OutputInfoSource::AUTO_GENERATED;
   }
 
-  nh_private_.param("queue_size", queue_size_, kQueueSize);
+  nh_private_.param("queue_size", queue_size_, kImageQueueSize);
   if (queue_size_ < 1) {
     ROS_ERROR("Queue size must be >= 1, setting to 1");
     queue_size_ = 1;


### PR DESCRIPTION
Allows voxblox_maplab_interface to interface between voxblox and maplab directly :)