### PR TITLE
Fix vector initialization and unitialized enum

### DIFF
--- a/src/camera_parameters.cpp
+++ b/src/camera_parameters.cpp
@@ -400,7 +400,7 @@ bool CameraParametersPair::setOptimalOutputCameraParameters(
   if (distortion_processing_ == DistortionProcessing::UNDISTORT) {
     D = input_ptr_->D();
   } else {
-    D = std::vector<double>(0, 7);
+    D = std::vector<double>(7, 0);
   }
 
   // Find the resolution of the output image

--- a/src/image_undistort.cpp
+++ b/src/image_undistort.cpp
@@ -58,9 +58,9 @@ ImageUndistort::ImageUndistort(const ros::NodeHandle& nh,
   nh_private_.param("undistort_image", undistort_image, kDefaultUndistortImage);
   DistortionProcessing distortion_processing;
   if (undistort_image) {
-    distortion_processing == DistortionProcessing::UNDISTORT;
+    distortion_processing = DistortionProcessing::UNDISTORT;
   } else {
-    distortion_processing == DistortionProcessing::PRESERVE;
+    distortion_processing = DistortionProcessing::PRESERVE;
   }
   camera_parameters_pair_ptr_ =
       std::make_shared<CameraParametersPair>(distortion_processing);


### PR DESCRIPTION
This is to fix two somewhat related bugs. First, `distortion_processing` was never assigned a value in the `image_undistort.cpp:60` if statement before being passed into the `CameraParametersPair` constructor. This is undefined behavior. Later when the comparison in `camera_parameters.cpp:400` occurs.
```cpp
  if (distortion_processing_ == DistortionProcessing::UNDISTORT) {
    D = input_ptr_->D();
  } else {
    D = std::vector<double>(0, 7);
  }
```
The comparison will yield unpredictable results depending on any number of factors. (In my case I compiled this code in clang)

If the code ever reaches the else statement the vector constructor is flipped such that a vector of size 0 would be constructed, resulting in a segfault later when it is being accessed.