### PR TITLE
Fix undistorter bug when undistort_image:=false

### DIFF
--- a/src/undistorter.cpp
+++ b/src/undistorter.cpp
@@ -21,7 +21,7 @@ Undistorter::Undistorter(
       DistortionProcessing::UNDISTORT) {
     D = used_camera_parameters_pair_.getInputPtr()->D();
   } else {
-    D = std::vector<double>(0, 5);
+    D = std::vector<double>(5, 0.0);
   }
 
   empty_pixels_ = false;


### PR DESCRIPTION
When the parameter `undistort_image` is `false`, the `image_undistort_node` segfaulted, because the vector `D` was initialized with size 0. This commit fixes that and initializes D with size 5.