### PR TITLE
Don't publish tf if input frame == output frame

### DIFF
--- a/src/image_undistort.cpp
+++ b/src/image_undistort.cpp
@@ -220,6 +220,8 @@ void ImageUndistort::imageCallback(
     }
     if (frame.empty()) {
       ROS_ERROR_ONCE("Image frame name is blank, cannot construct tf");
+      } else if (frame == output_frame_) {
+        ROS_ERROR_ONCE("Input and output frame are identical ('%s'), cannot construct tf", frame.c_str());
     } else {
       br_.sendTransform(tf::StampedTransform(tf::Transform(R_ros, p_ros),
                                              image_out_ptr->header.stamp, frame,

--- a/src/stereo_undistort.cpp
+++ b/src/stereo_undistort.cpp
@@ -246,6 +246,8 @@ void StereoUndistort::processAndSendImage(
       }
       if (frame.empty()) {
         ROS_ERROR_ONCE("Image frame name is blank, cannot construct tf");
+      } else if (frame == first_output_frame_) {
+        ROS_ERROR_ONCE("Input and output frame are identical ('%s'), cannot construct tf", frame.c_str());
       } else {
         br_.sendTransform(tf::StampedTransform(tf::Transform(R_ros, p_ros),
                                                image_out_ptr->header.stamp,
@@ -275,6 +277,8 @@ void StereoUndistort::processAndSendImage(
       }
       if (frame.empty()) {
         ROS_ERROR_ONCE("Image frame name is blank, cannot construct tf");
+      } else if (frame == first_output_frame_) {
+        ROS_ERROR_ONCE("Input and output frame are identical ('%s'), cannot construct tf", frame.c_str());
       } else {
         br_.sendTransform(tf::StampedTransform(tf::Transform(R_ros, p_ros),
                                                image_out_ptr->header.stamp,


### PR DESCRIPTION
Otherwise, this will cause tf errors like this in subscribing nodes:

    Error:   TF_SELF_TRANSFORM: Ignoring transform from authority "/stereo_undistort" with frame_id and child_frame_id  "boson_right_optical_frame" because they are the same
             at line 221 in /tmp/binarydeb/ros-kinetic-tf2-0.5.20/src/buffer_core.cpp