### PR TITLE
compile under Ubuntu 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,21 @@
 cmake_minimum_required(VERSION 2.8.3)
+if(NOT ${CMAKE_VERSION} VERSION_LESS "3.0.2")
+  if (POLICY CMP0048)
+    cmake_policy(SET CMP0048 NEW)
+  endif (POLICY CMP0048)
+endif()
 
 project(image_undistort)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 # Set compile flags (-Ofast actually makes a big difference over -O3 here (maybe 20% faster)
-set(CMAKE_CXX_FLAGS "-std=c++11 -Ofast")
+if(${CMAKE_VERSION} VERSION_LESS "3.1.0")
+  set(CMAKE_CXX_FLAGS "-std=c++11 -Ofast")
+else()
+  set(CMAKE_CXX_FLAGS "-Ofast")
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 find_package(Eigen3 REQUIRED)
 find_package(catkin REQUIRED COMPONENTS

--- a/include/image_undistort/undistorter.h
+++ b/include/image_undistort/undistorter.h
@@ -3,8 +3,6 @@
 
 #include <Eigen/Dense>
 
-#include <cv.h>
-#include <highgui.h>
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include "image_undistort/camera_parameters.h"


### PR DESCRIPTION
As it stands, the repo does not compile under Ubuntu 20.04 for two reasons:
1) The pcl_ros catkin package requires C++14 standard
2) The default version of opencv is now 4, which does not have the old "cv.h" headers

Further, there is a cmake warning about policy CMP0048 that should be suppressed.

This PR fixes the above issues and was tested to compile under ubuntu versions 14.04, 16.04, 18.04 and 20.04