### PR TITLE
Add install for executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,16 @@ install(TARGETS ${PROJECT_NAME}_nodelet
   DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
 
+# Install general executables
+install(
+  TARGETS
+    depth_node
+    dense_stereo_node
+    image_undistort_node
+    stereo_info_node
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 # Install header files
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}


### PR DESCRIPTION
Adds install for general executables (all except the `point_to_bearing_node` because I'm lazy and can't test that).